### PR TITLE
Add argument in get_cpu_offload_context

### DIFF
--- a/megatron/core/transformer/transformer_block.py
+++ b/megatron/core/transformer/transformer_block.py
@@ -150,10 +150,11 @@ class TransformerBlock(MegatronModule):
                 self.offload_context,
                 self.group_prefetch_offload_commit_async,
             ) = get_cpu_offload_context(
-                self.config.cpu_offloading,
-                self.config.cpu_offloading_num_layers,
-                self.config.cpu_offloading_activations,
-                self.config.cpu_offloading_weights,
+                enabled=self.config.cpu_offloading,
+                num_layers=self.config.cpu_offloading_num_layers,
+                model_layers=self.config.num_layers,
+                offload_activations=self.config.cpu_offloading_activations,
+                offload_weights=self.config.cpu_offloading_weights
             )
             self.config._cpu_offloading_context = (
                 self.offload_context if self.config.cpu_offloading else None


### PR DESCRIPTION
In https://github.com/NVIDIA/TransformerEngine/commit/c8c05f38b773d7509c43dbdbb52cddf58aac6962, `get_cpu_offload_context()` extend its argument list with a new `model_layers` member. We need to add this value in all calls to avoid mismatch.